### PR TITLE
Add Glide and make repeatable builds with latest rackhd bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+vendor
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -33,3 +34,6 @@ commands.md
 *.Darwin-x86_64
 *.Linux-x86_64
 *.Windows-x86_64
+
+# Glide
+glide.lock

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/emccode/docker-machine-rackhd
+import:
+- package: github.com/emccode/gorackhd
+  subpackages:
+  - client
+  - models
+  vcs: git
+  ref: 3eadf9e9eafd10a32c7ddf7e464f200f61d08044
+- package: github.com/emccode/gorackhd-redfish
+  subpackages:
+  - client
+  - models
+  vcs: git
+  ref: b33dab80a8736bb7cdab735867bd7cc2d668c6e0

--- a/rackhd.go
+++ b/rackhd.go
@@ -302,30 +302,33 @@ func (d *Driver) GetState() (state.State, error) {
 		return state.None, errObm
 	}
 
-	//If there is no obm (such as Vagrant), send back as Running
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		return state.Running, nil
-	default:
-		//Generate the client
-		clientRedfish := d.getClientRedfish()
-
-		// do a lookup on the Node ID to retrieve Power information
-		resp, err := clientRedfish.RedfishV1.GetSystem(&redfish_v1.GetSystemParams{Identifier: d.NodeID})
-		if err != nil {
-			return state.None, nil
-		}
-		switch resp.Payload.PowerState {
-		case "Online", "online", "Up", "up", "On", "on":
+	if len(respObm.Payload) > 0 {
+		//If there is no obm (such as Vagrant), send back as Running
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
 			return state.Running, nil
-		case "Offline", "offline", "Down", "down", "Off", "off":
-			return state.Stopped, nil
-		case "Unknown", "unknown":
-			return state.None, nil
 		default:
-			return state.Running, nil
+			//Generate the client
+			clientRedfish := d.getClientRedfish()
+
+			// do a lookup on the Node ID to retrieve Power information
+			resp, err := clientRedfish.RedfishV1.GetSystem(&redfish_v1.GetSystemParams{Identifier: d.NodeID})
+			if err != nil {
+				return state.None, nil
+			}
+			switch resp.Payload.PowerState {
+			case "Online", "online", "Up", "up", "On", "on":
+				return state.Running, nil
+			case "Offline", "offline", "Down", "down", "Off", "off":
+				return state.Stopped, nil
+			case "Unknown", "unknown":
+				return state.None, nil
+			default:
+				return state.Running, nil
+			}
 		}
 	}
+	return state.None, nil
 }
 
 func (d *Driver) Start() error {
@@ -337,26 +340,29 @@ func (d *Driver) Start() error {
 		return errObm
 	}
 
-	//If there is no obm (such as Vagrant), nil
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		return fmt.Errorf("OBM %#v Type Not Supported For Starting: %#v", "noop-obm-service", d.NodeID)
-	default:
-		log.Debugf("Attempting Turn On: %#v", d.NodeID)
-		action := &modelsRedfish.RackHDResetAction{
-			ResetType: "On",
+	if len(respObm.Payload) > 0 {
+		//If there is no obm (such as Vagrant), nil
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
+			return fmt.Errorf("OBM %#v Type Not Supported For Starting: %#v", "noop-obm-service", d.NodeID)
+		default:
+			log.Debugf("Attempting Turn On: %#v", d.NodeID)
+			action := &modelsRedfish.RackHDResetAction{
+				ResetType: "On",
+			}
+
+			clientRedfish := d.getClientRedfish()
+
+			_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
+			if err != nil {
+				return fmt.Errorf("There was an issue Powering On the Server. Error: %s", err)
+			}
+
+			log.Debugf("Node has succussfully been powered on: %#v", d.NodeID)
+			return nil
 		}
-
-		clientRedfish := d.getClientRedfish()
-
-		_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
-		if err != nil {
-			return fmt.Errorf("There was an issue Powering On the Server. Error: %s", err)
-		}
-
-		log.Debugf("Node has succussfully been powered on: %#v", d.NodeID)
-		return nil
 	}
+	return fmt.Errorf("There was an issue Powering On the Server. No OBM detected")
 }
 
 func (d *Driver) Stop() error {
@@ -367,25 +373,28 @@ func (d *Driver) Stop() error {
 		return errObm
 	}
 
-	//If there is no obm (such as Vagrant), nil
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		return fmt.Errorf("OBM %#v Type Not Supported For Stopping: %#v", "noop-obm-service", d.NodeID)
-	default:
-		log.Debugf("Attempting Graceful Shutdown of: %#v", d.NodeID)
-		action := &modelsRedfish.RackHDResetAction{
-			ResetType: "GracefulShutdown",
-		}
+	if len(respObm.Payload) > 0{
+		//If there is no obm (such as Vagrant), nil
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
+			return fmt.Errorf("OBM %#v Type Not Supported For Stopping: %#v", "noop-obm-service", d.NodeID)
+		default:
+			log.Debugf("Attempting Graceful Shutdown of: %#v", d.NodeID)
+			action := &modelsRedfish.RackHDResetAction{
+				ResetType: "GracefulShutdown",
+			}
 
-		clientRedfish := d.getClientRedfish()
+			clientRedfish := d.getClientRedfish()
 
-		_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
-		if err != nil {
-			return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
+			if err != nil {
+				return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			}
+			log.Debugf("Node has succussfully been shutdown: %#v", d.NodeID)
+			return nil
 		}
-		log.Debugf("Node has succussfully been shutdown: %#v", d.NodeID)
-		return nil
 	}
+	return fmt.Errorf("There was an issue Shutting Down the Server. Error: No OBM detected")
 }
 
 func (d *Driver) Remove() error {
@@ -396,25 +405,29 @@ func (d *Driver) Remove() error {
 		return errObm
 	}
 
-	//If there is no obm (such as Vagrant), nil
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		log.Debugf("OBM %#v Type Not Supported For Shutdown: %#v", "noop-obm-service", d.NodeID)
-	default:
-		log.Debugf("Attempting Graceful Shutdown of: %#v", d.NodeID)
-		action := &modelsRedfish.RackHDResetAction{
-			ResetType: "GracefulShutdown",
-		}
+	if len(respObm.Payload) > 0{
+		//If there is no obm (such as Vagrant), nil
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
+			log.Debugf("OBM %#v Type Not Supported For Shutdown: %#v", "noop-obm-service", d.NodeID)
+		default:
+			log.Debugf("Attempting Graceful Shutdown of: %#v", d.NodeID)
+			action := &modelsRedfish.RackHDResetAction{
+				ResetType: "GracefulShutdown",
+			}
 
-		clientRedfish := d.getClientRedfish()
+			clientRedfish := d.getClientRedfish()
 
-		_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
-		if err != nil {
-			log.Infof("There was an issue Shutting Down the Server. Error: %s", err)
-			//return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
-		} else {
-			log.Debugf("Node has succussfully been shutdown: %#v", d.NodeID)
+			_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
+			if err != nil {
+				log.Infof("There was an issue Shutting Down the Server. Error: %s", err)
+				//return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			} else {
+				log.Debugf("Node has succussfully been shutdown: %#v", d.NodeID)
+			}
 		}
+	} else {
+		log.Infof("There was an issue Shutting Down the Server. Error: No OBM detected")
 	}
 
 	//Remove the Node from RackHD Inventory
@@ -436,25 +449,28 @@ func (d *Driver) Restart() error {
 		return errObm
 	}
 
-	//If there is no obm (such as Vagrant), nil
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		return fmt.Errorf("OBM Type Not Supported: %#v, %#v", "noop-obm-service", d.NodeID)
-	default:
-		log.Debugf("Attempting Restart of: %#v", d.NodeID)
-		action := &modelsRedfish.RackHDResetAction{
-			ResetType: "GracefulRestart",
-		}
+	if len(respObm.Payload) > 0 {
+		//If there is no obm (such as Vagrant), nil
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
+			return fmt.Errorf("OBM Type Not Supported: %#v, %#v", "noop-obm-service", d.NodeID)
+		default:
+			log.Debugf("Attempting Restart of: %#v", d.NodeID)
+			action := &modelsRedfish.RackHDResetAction{
+				ResetType: "GracefulRestart",
+			}
 
-		clientRedfish := d.getClientRedfish()
+			clientRedfish := d.getClientRedfish()
 
-		_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
-		if err != nil {
-			return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
+			if err != nil {
+				return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			}
+			log.Debugf("Successfully restarted node: %#v", d.NodeID)
+			return nil
 		}
-		log.Debugf("Successfully restarted node: %#v", d.NodeID)
-		return nil
 	}
+	return fmt.Errorf("There was an issue Shutting Down the Server. Error: No OBM detected")
 }
 
 func (d *Driver) Kill() error {
@@ -465,25 +481,28 @@ func (d *Driver) Kill() error {
 		return errObm
 	}
 
-	//If there is no obm (such as Vagrant), nil
-	switch respObm.Payload.([]interface{})[0].(map[string]interface{})["service"] {
-	case "noop-obm-service":
-		return fmt.Errorf("OBM Type Not Supported: %#v, %#v", "noop-obm-service", d.NodeID)
-	default:
-		log.Debugf("Attempting Force Off of: %#v", d.NodeID)
-		action := &modelsRedfish.RackHDResetAction{
-			ResetType: "ForceOff",
-		}
+	if len(respObm.Payload) > 0 {
+		//If there is no obm (such as Vagrant), nil
+		switch respObm.Payload[0].(map[string]interface{})["service"] {
+		case "noop-obm-service":
+			return fmt.Errorf("OBM Type Not Supported: %#v, %#v", "noop-obm-service", d.NodeID)
+		default:
+			log.Debugf("Attempting Force Off of: %#v", d.NodeID)
+			action := &modelsRedfish.RackHDResetAction{
+				ResetType: "ForceOff",
+			}
 
-		clientRedfish := d.getClientRedfish()
+			clientRedfish := d.getClientRedfish()
 
-		_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
-		if err != nil {
-			return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			_, err := clientRedfish.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: d.NodeID, Payload: action})
+			if err != nil {
+				return fmt.Errorf("There was an issue Shutting Down the Server. Error: %s", err)
+			}
+			log.Debugf("Successfully turned off node: %#v", d.NodeID)
+			return nil
 		}
-		log.Debugf("Successfully turned off node: %#v", d.NodeID)
-		return nil
 	}
+	return fmt.Errorf("There was an issue Shutting Down the Server. Error: No OBM detected")
 }
 
 func (d *Driver) getClientMonorail() *apiclientMonorail.Monorail {

--- a/rackhd.go
+++ b/rackhd.go
@@ -15,8 +15,12 @@ import (
 	"github.com/emccode/gorackhd/client/lookups"
 	"github.com/emccode/gorackhd/client/nodes"
 
-	httptransport "github.com/go-swagger/go-swagger/httpkit/client"
-	"github.com/go-swagger/go-swagger/strfmt"
+	// Need the *old* style libraries for redfish
+	red_httptransport "github.com/go-swagger/go-swagger/httpkit/client"
+	red_strfmt "github.com/go-swagger/go-swagger/strfmt"
+
+	mono_httptransport "github.com/go-openapi/runtime/client"
+	mono_strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
@@ -487,9 +491,9 @@ func (d *Driver) getClientMonorail() *apiclientMonorail.Monorail {
 	if d.clientMonorail == nil {
 		// create the transport
 		/** Will Need to determine changes for v 2.0 API **/
-		transport := httptransport.New(d.Endpoint, "/api/1.1", []string{d.Transport})
+		transport := mono_httptransport.New(d.Endpoint, "/api/1.1", []string{d.Transport})
 		// create the API client, with the transport
-		d.clientMonorail = apiclientMonorail.New(transport, strfmt.Default)
+		d.clientMonorail = apiclientMonorail.New(transport, mono_strfmt.Default)
 	}
 	return d.clientMonorail
 }
@@ -498,9 +502,9 @@ func (d *Driver) getClientRedfish() *apiclientRedfish.Redfish {
 	log.Debugf("Getting RackHD Redfish Client")
 	if d.clientRedfish == nil {
 		// create the transport
-		transport := httptransport.New(d.Endpoint, "/redfish/v1", []string{d.Transport})
+		transport := red_httptransport.New(d.Endpoint, "/redfish/v1", []string{d.Transport})
 		// create the API client, with the transport
-		d.clientRedfish = apiclientRedfish.New(transport, strfmt.Default)
+		d.clientRedfish = apiclientRedfish.New(transport, red_strfmt.Default)
 	}
 	return d.clientRedfish
 }


### PR DESCRIPTION
This introduces a Glide file so that we create repeatable builds of the binary.

In order to make things compile, I needed to fix the way some of the type assertions were done, and deal  with the fact that `gorackhd` and `gorackhd-redfish` are built using different versions of swagger (and those different versions have an incompatible change for importing libraries like `strfmt` and `httpkit`.
