### PR TITLE
Add --rackhd-sku-id support

### DIFF
--- a/rackhd.go
+++ b/rackhd.go
@@ -179,19 +179,23 @@ func (d *Driver) PreCreateCheck() error {
 	}
 
 	log.Infof("Test Passed. %v Monorail and Redfish API's are accessible and installation will begin", d.Endpoint)
+
+	if (d.SkuID != "") {
+		log.Infof("Looking for available node within SKU")
+		err := d.chooseNode(clientMonorail)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Infof("Found a free node with SKU, Node ID: %v", d.NodeID)
+
 	return nil
 }
 
 func (d *Driver) Create() error {
 	//Generate the client
 	client := d.getClientMonorail()
-
-	if (d.SkuID != "") {
-		err := d.chooseNode(client)
-		if err != nil {
-			return err
-		}
-	}
 
 	return d.provisionNode(client)
 }

--- a/rackhd.go
+++ b/rackhd.go
@@ -227,6 +227,11 @@ func (d *Driver) chooseNode(client * apiclientMonorail.Monorail) error{
 	}
 
 	d.NodeID = chosenNode.ID
+
+	err = d.tagNode(d.NodeID, "dockermachine")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -561,6 +566,20 @@ func (d *Driver) Kill() error {
 		}
 	}
 	return fmt.Errorf("There was an issue Shutting Down the Server. Error: No OBM detected")
+}
+
+func (d *Driver) tagNode(targetNode, targetTag string) error {
+	clientMonorail := d.getClientMonorail()
+	params := nodes.NewPatchNodesIdentifierTagsParams()
+	body := make(map[string]interface{})
+	var tags [1]string
+	tags[0] = targetTag
+	body["tags"] = tags
+
+	params.WithBody(body)
+	params.WithIdentifier(targetNode)
+	_, err := clientMonorail.Nodes.PatchNodesIdentifierTags(params, nil)
+	return err
 }
 
 func (d *Driver) getClientMonorail() *apiclientMonorail.Monorail {

--- a/rackhd_test.go
+++ b/rackhd_test.go
@@ -1,0 +1,95 @@
+package rackhd
+
+import (
+	"testing"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDriverName(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	if "rackhd" != d.DriverName() {
+		t.FailNow()
+	}
+}
+
+func testSetDefaults(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-sku-id": "aabbccdd",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+
+	assert.Equal(t, "http", d.Transport)
+	assert.Equal(t, "root", d.SSHUser)
+	assert.Equal(t, "root", d.SSHPassword)
+	assert.Equal(t, 22, d.SSHPort)
+
+	// Not part of the default, but check to see that it's set
+	assert.Equal(t, "aabbccdd", d.SkuID)
+}
+
+func TestSetEndpoint(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-endpoint": "localhost:9090",
+			"rackhd-node-id": "aabbccdd",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+
+	assert.Equal(t, "localhost:9090", d.Endpoint)
+}
+
+func TestNodeOrSkuIDRequired(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-endpoint": "localhost:9090",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.Error(t, err, "Should error if no SKU or Node ID is given")
+}
+
+func TestOnlyNodeOrSkuIDAllowed(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-node-id": "aabbccdd",
+			"rackhd-sku-id": "eeffgghh",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.Error(t, err, "Should error if both SKU and Node ID is given")
+}


### PR DESCRIPTION
This PR adds support for the `--rackhd-sku-id` flag. This flag is mutually exclusive with `--rackhd-node-id`, and one of these is still required.

When passed, the SKU ID is used in the PreCreate() code to get a list of nodes belonging to the SKU, and picking the first one that does _not_ have a **dockermachine** tag. It then tags the node with **dockermachine** and currently proceeds as the driver always has.

At this point, we are not adding anything for workflows (e.g. OS installs), that's in a later PR. Nothing is done at this point to untag a node, either. But when you delete a node via `docker-machine` it removes the node from RackHD's inventory entirely, so it's a non-issue. I'm not sure that approach works long term, but that's a separate issue.

Might be easier to review this PR commit by commit, to see the progression. Some simple tests were added at the very end.

This should close #7 .
