### PR TITLE
Add --rackhd-sku-name option

### DIFF
--- a/rackhd_test.go
+++ b/rackhd_test.go
@@ -48,7 +48,7 @@ func TestSetEndpoint(t *testing.T) {
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
 			"rackhd-endpoint": "localhost:9090",
-			"rackhd-node-id": "aabbccdd",
+			"rackhd-node-id":  "aabbccdd",
 		},
 		CreateFlags: d.GetCreateFlags(),
 	}
@@ -84,7 +84,7 @@ func TestOnlyNodeOrSkuIDAllowed(t *testing.T) {
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
 			"rackhd-node-id": "aabbccdd",
-			"rackhd-sku-id": "eeffgghh",
+			"rackhd-sku-id":  "eeffgghh",
 		},
 		CreateFlags: d.GetCreateFlags(),
 	}
@@ -92,4 +92,38 @@ func TestOnlyNodeOrSkuIDAllowed(t *testing.T) {
 	err := d.SetConfigFromFlags(checkFlags)
 
 	assert.Error(t, err, "Should error if both SKU and Node ID is given")
+}
+
+func TestOnlyNodeOrSkuNameAllowed(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-node-id":  "aabbccdd",
+			"rackhd-sku-name": "test sku",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.Error(t, err, "Should error if both SKU Name and Node ID are given")
+}
+
+func TestOnlySkuNameOrSkuIDAllowed(t *testing.T) {
+	// create the Driver
+	d := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"rackhd-sku-id":   "aabbccdd",
+			"rackhd-sku-name": "test sku",
+		},
+		CreateFlags: d.GetCreateFlags(),
+	}
+
+	err := d.SetConfigFromFlags(checkFlags)
+
+	assert.Error(t, err, "Should error if both SKU Name and ID are given")
 }


### PR DESCRIPTION
The new `--rackhd-sku-name` option presents a friendlier alternative to `--rackhd-sku-id`. If you happen to know the name of the SKU, we can use that to lookup the ID for you.  That allows a command like this:

`docker-machine create -d rackhd --rackhd-endpoint "localhost:9090" --rackhd-sku-name "Small RAM node" test1`

Here is example output from that command, showing it working:

```
$ docker-machine -D create -d rackhd --rackhd-endpoint "localhost:9090" --rackhd-sku-name "Small RAM node" test1
Docker Machine Version:  0.8.0-rc1, build fffa6c9
Found binary path at /usr/local/bin/docker-machine-driver-rackhd
Launching plugin server for driver rackhd
Plugin server listening at address 127.0.0.1:62007
() Calling .GetVersion
Using API Version  1
() Calling .SetConfigRaw
() Calling .GetMachineName
(flag-lookup) Calling .GetMachineName
(flag-lookup) Calling .DriverName
(flag-lookup) Calling .GetCreateFlags
Found binary path at /usr/local/bin/docker-machine-driver-rackhd
Launching plugin server for driver rackhd
Plugin server listening at address 127.0.0.1:62011
() Calling .GetVersion
Using API Version  1
() Calling .SetConfigRaw
() Calling .GetMachineName
(test1) Calling .GetMachineName
(test1) Calling .DriverName
(test1) Calling .GetCreateFlags
(test1) Calling .SetConfigFromFlags
Running pre-create checks...
(test1) Calling .PreCreateCheck
(test1) Testing accessibility of endpoint: localhost:9090
(test1) DBG | Getting RackHD Monorail Client
(test1) DBG | Getting RackHD Redfish Client
(test1) DBG | Looking up SKU ID by name
(test1) Test Passed. localhost:9090 Monorail and Redfish API's are accessible and installation will begin
(test1) DBG | [GET /skus][200] getSkusOK  [map[name:Small RAM node discoveryGraphName:Graph.DefaultRancherNode.Standby rules:[map[path:total-memory-mb.memoryMb lessThan:4096]] createdAt:2016-07-08T16:16:33.831Z updatedAt:2016-07-08T16:16:33.831Z id:577fd1e1d601b00100efc591] map[name:Large RAM node discoveryGraphName:Graph.DefaultRancherNode.Standby rules:[map[path:total-memory-mb.memoryMb greaterThan:4095]] createdAt:2016-07-08T16:16:33.876Z updatedAt:2016-07-08T16:16:33.876Z id:577fd1e1d601b00100efc592]]
(test1) Looking for available node within SKU
(test1) DBG | [GET /skus/{identifier}/nodes][200] getSkusIdentifierNodesOK  [map[name:08:00:27:50:49:07 tags:[] createdAt:2016-07-08T17:34:28.337Z sku:577fd1e1d601b00100efc591 identifiers:[08:00:27:50:49:07] type:compute autoDiscover:false relations:[map[relationType:enclosedBy targets:[577fe4738c811401003446b4]]] updatedAt:2016-07-08T17:35:47.789Z obmSettings:[map[service:noop-obm-service config:map[]]] id:577fe424d601b00100efc593]]
(test1) DBG | Getting RackHD Monorail Client
(test1) Found a free node with SKU, Node ID: 577fe424d601b00100efc593
(test1) Calling .GetConfigRaw
Creating machine...
(test1) Calling .Create
(test1) DBG | Getting RackHD Monorail Client
(test1) DBG | Found IP Address for Node ID: 172.31.128.3
```

And the resulting docker-machine config:

```
$ cat ~/.docker/machine/machines/test1/config.json
{
    "ConfigVersion": 3,
    "Driver": {
        "IPAddress": "",
        "MachineName": "test1",
        "SSHKeyPath": "",
        "StorePath": "/Users/travis/.docker/machine",
        "SwarmMaster": false,
        "SwarmHost": "",
        "SwarmDiscovery": "",
        "Endpoint": "localhost:9090",
        "NodeID": "577fe424d601b00100efc593",
        "SkuID": "577fd1e1d601b00100efc591",
        "SkuName": "Small RAM node",
        "SSHUser": "root",
        "SSHPassword": "root",
        "SSHPort": 22,
        "SSHKey": "",
        "Transport": "http"
    },
....
```

Note that the option can accept a SKU name with spaces, so long as it is properly quoted.

Closes #8.
