### PR TITLE
Add --rackhd-workflow-name

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
   - client
   - models
   vcs: git
-  ref: 3eadf9e9eafd10a32c7ddf7e464f200f61d08044
+  ref: 83577fdb275678683da184ddda2856532bf197a9
 - package: github.com/emccode/gorackhd-redfish
   subpackages:
   - client

--- a/rackhd.go
+++ b/rackhd.go
@@ -260,7 +260,7 @@ func (d *Driver) chooseNode(client *apiclientMonorail.Monorail) error {
 func (d *Driver) provisionNode(client *apiclientMonorail.Monorail) error {
 
 	// do a lookup on the ID to retrieve IP information
-	resp, err := client.Lookups.GetLookups(&lookups.GetLookupsParams{Q: d.NodeID}, nil)
+	resp, err := client.Lookups.GetLookups(&lookups.GetLookupsParams{Q: &d.NodeID}, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When the workflow name is given (e.g. "Graph.InstallCoreOS"), that
workflow will be set on the node. The driver will then wait for
the workflow to finish before moving on.

The intent of the flag is to allow for OS installation. The timeouts
associated with waiting for the workflow to finish are currently
hardcoded to waiting for 60 minutes, and polled every 15 seconds.

Resolves #9 
