### PR TITLE
Add --rackhd-ssh-key option

### DIFF
--- a/rackhd.go
+++ b/rackhd.go
@@ -220,9 +220,8 @@ func (d *Driver) PreCreateCheck() error {
 		if err != nil {
 			return err
 		}
+		log.Infof("Found a free node within SKU, Node ID: %v", d.NodeID)
 	}
-
-	log.Infof("Found a free node with SKU, Node ID: %v", d.NodeID)
 
 	if d.SSHKeyPath == "" {
 		log.Infof("No SSH Key specified. Will attempt login with user/pass and upload generated key pair")


### PR DESCRIPTION
When this new option is given, it is the path to an existing private
key, and it is assumed that the public key is already present on the
node.

Store this key path in the base driver's existing SSHKeyPath field,
there is no reason for our driver to store an additional SSHKey
field.

We use the private key from where we are pointed at. The docker-machine
generic driver copies it into the store path, but I'm not in the habit
of making multiple copies of SSH private keys, so we just use it
directly. If this choice proves to be undesired, it's easy to change.

Closes #13 
