### PR TITLE
Add some adjustable timeouts

### DIFF
--- a/rackhd.go
+++ b/rackhd.go
@@ -194,11 +194,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = flags.String("rackhd-ssh-user")
 	d.SSHPassword = flags.String("rackhd-ssh-password")
 	d.SSHPort = flags.Int("rackhd-ssh-port")
-	if d.SSHPort == 443 {
-		d.Transport = "https"
-	} else {
-		d.Transport = flags.String("rackhd-transport")
-	}
+	d.Transport = flags.String("rackhd-transport")
 
 	d.SSHKeyPath = flags.String("rackhd-ssh-key")
 	if d.SSHKeyPath != "" {

--- a/rackhd.go
+++ b/rackhd.go
@@ -91,24 +91,26 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "RACKHD_TRANSPORT",
 			Name:   "rackhd-transport",
-			Usage:  "RackHD Endpoint Transport. Specify http or https. HTTP is default",
+			Usage:  "RackHD Endpoint Transport. Specify http or https.",
 			Value:  defaultTransport,
 		},
 		mcnflag.StringFlag{
 			EnvVar: "RACKHD_SSH_USER",
 			Name:   "rackhd-ssh-user",
-			Usage:  "ssh user (default:root)",
+			Usage:  "SSH user",
+			Value:  drivers.DefaultSSHUser,
 		},
 		mcnflag.StringFlag{
 			EnvVar: "RACKHD_SSH_PASSWORD",
 			Name:   "rackhd-ssh-password",
-			Usage:  "ssh password (default:root)",
+			Usage:  "SSH password",
 			Value:  defaultSSHPassword,
 		},
 		mcnflag.IntFlag{
 			EnvVar: "RACKHD_SSH_PORT",
 			Name:   "rackhd-ssh-port",
-			Usage:  "ssh port (default:22)",
+			Usage:  "SSH port",
+			Value:  drivers.DefaultSSHPort,
 		},
 		mcnflag.StringFlag{
 			EnvVar: "RACKHD_SSH_KEY",


### PR DESCRIPTION
This adds configurable timeouts related to workflow (how long to wait until finished, how often do we check) and checking that the node is accessible via SSH (how many times do we try, how long do we wait between attempts).

Also a few other cleanups related to default value output from `--help` and code that was strangely changing transport type based on the SSH port.

With these changes, I can now run the following command successfully:

```
docker-machine --debug create --driver rackhd --rackhd-endpoint localhost:9090 --rackhd-sku-name RancherSmallNode --rackhd-workflow-name Graph.InstallCoreOS --rackhd-ssh-key ~/git/RackHD/on-http/data/rackhd_rsa --rackhd-ssh-user core test1
```

This picks a node that has previously been discovered and sorted into the `RancherSmallNode` SKU, powers it on via IPMI, installs CoreOS, waits for SSH to be available, and then docker-machine does its magic to install Docker.

On my test hardware at home this process takes about 8 minutes.
